### PR TITLE
Feature/#31 #32 #33

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /docs/API.md
 .idea
 *.iml
+/VERSION.txt
 node_modules
 /.project
 /.settings/*

--- a/docs/BADGES.md
+++ b/docs/BADGES.md
@@ -2,9 +2,9 @@
 
 ## General
 
-| [Github License](https://github.com/deadratfink/jy-transform/blob/master/LICENSE.md) | [Github Issues](https://github.com/deadratfink/jy-transform/issues) | [Github Release](https://github.com/deadratfink/jy-transform/releases) | [Github Tags](https://github.com/deadratfink/jy-transform/tags) | [Travis CI](https://travis-ci.org) | [Waffle](https://waffle.io/deadratfink/jy-transform) | [Code Climate](https://codeclimate.com/github/deadratfink/jy-transform) |
+| [License](https://github.com/deadratfink/jy-transform/blob/master/LICENSE.md) | [Issues](https://github.com/deadratfink/jy-transform/issues) | [Releases](https://github.com/deadratfink/jy-transform/releases) | [Tags](https://github.com/deadratfink/jy-transform/tags) | [Travis CI](https://travis-ci.org) | [Waffle](https://waffle.io/deadratfink/jy-transform) | [Code Climate](https://codeclimate.com/github/deadratfink/jy-transform) |
 | --- | --- | --- | --- | --- | --- | --- |
-| [![License][gh-license-image]][gh-license-url] | [![Issue Stats][gh-issues-image]][gh-issues-url] | [![Github Releases][gh-releases-image]][gh-releases-url] | [![Github Tags][gh-tags-image]][gh-tags-url] | [![Build Status][ci-image]][ci-url] | [![Waffle][waffle-image]][waffle-url] | [![Code Climate][cocl-image]][cocl-url] |
+| [![License][gh-license-image]][gh-license-url] | [![Issue Stats][gh-issues-image]][gh-issues-url] | [![Releases][gh-releases-image]][gh-releases-url] | [![Tags][gh-tags-image]][gh-tags-url] | [![Build Status][ci-image]][ci-url] | [![Waffle][waffle-image]][waffle-url] | [![Code Climate][cocl-image]][cocl-url] |
 
 ## Branches
 
@@ -13,12 +13,16 @@
 | master | [![codecov.io][cc-image-master]][cc-url-master]           | [![coveralls.io][ca-image-master]][ca-url-master]           | [![inch-ci.org][inch-image-master]][inch-url-master]           | [![Dependency Status][dep-image-master]][dep-url-master]           | [![devDependency Status][devdep-image-master]][devdep-url-master] |
 | development | [![codecov.io][cc-image-development]][cc-url-development] | [![coveralls.io][ca-image-development]][ca-url-development] | [![inch-ci.org][inch-image-development]][inch-url-development] | [![Dependency Status][dep-image-development]][dep-url-development] | [![devDependency Status][devdep-image-development]][devdep-url-development] |
 
-### Coverage Graphs
+### Coverage
 
-| Branch | Graph |
+| master | development |
 | --- | --- |
-| master | ![codecov.io](https://codecov.io/github/deadratfink/jy-transform/branch.svg?branch=master&vg=true) |
-| development| ![codecov.io](https://codecov.io/github/deadratfink/jy-transform/branch.svg?branch=development&vg=true) |
+| ![codecov.io](https://codecov.io/gh/deadratfink/jy-transform/branch/master/graphs/tree.svg) | ![codecov.io](https://codecov.io/gh/deadratfink/jy-transform/branch/development/graphs/tree.svg) |
+
+<!--| Branch | Graph | -->
+<!--| --- | --- | -->
+<!--| master | ![codecov.io](https://codecov.io/github/deadratfink/jy-transform/branch.svg?branch=master&vg=true) | -->
+<!--| development| ![codecov.io](https://codecov.io/github/deadratfink/jy-transform/branch.svg?branch=development&vg=true) | -->
 
 ## NPM
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-### v2.0.0
+### v2.0.0 (NOT RELEASED YET!!!)
 
-- [[#32](https://github.com/deadratfink/jy-transform/issues/32)] Introduce input and output on CLI as ARGS instead of OPTIONS (non-backwards compatible change for CLI usage!)
+
+- [[#33](https://github.com/deadratfink/jy-transform/issues/33)] Enhance `LogWrapper` with `TRACE` level (API)
+- [[#32](https://github.com/deadratfink/jy-transform/issues/32)] Introduce input and output on CLI as ARGS instead of OPTIONS (non-backwards compatible change for CLI usage, _no_ impact on API level!)
  - E.g. type `$ jyt foo.js bar.yaml` instead of `$ jyt -s foo.js -d bar.yaml`
 - [[#31](https://github.com/deadratfink/jy-transform/issues/31)] Fix: given `Object` source results in 'yaml' for origin (API)
 - [[#26](https://github.com/deadratfink/jy-transform/issues/26)] API level `dest`: support for writing serialized JSON and YAML to _single_ (i.e. non-streamed) `Buffer` 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,12 +7,6 @@
 - [[#32](https://github.com/deadratfink/jy-transform/issues/32)] Introduce input and output on CLI as ARGS instead of OPTIONS (non-backwards compatible change for CLI usage, _no_ impact on API level!)
  - E.g. type `$ jyt foo.js bar.yaml` instead of `$ jyt -s foo.js -d bar.yaml`
 - [[#31](https://github.com/deadratfink/jy-transform/issues/31)] Fix: given `Object` source results in 'yaml' for origin (API)
-- [[#26](https://github.com/deadratfink/jy-transform/issues/26)] API level `dest`: support for writing serialized JSON and YAML to _single_ (i.e. non-streamed) `Buffer` 
- - Requires `options.target` property set
- - Writes UTF-8 to Buffer
-- [[#25](https://github.com/deadratfink/jy-transform/issues/25)] API level `src`: support for reading serialized JSON and YAML from _single_ (i.e. non-streamed) `Buffer`
- - Requires `options.origin` property set
- - Expects UTF-8 data in Buffer
 
 ### v1.0.2
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -38,17 +38,17 @@ Reading from:
 - _*.js_ file
 - _*.json_ file
 
-Additionally, on API level to:
+Additionally, on API level to a:
 
-- a `stream.Readable` 
+- `stream.Readable` 
  - Serialized JSON and YAML
  - Requires `options.origin` property set
  - Reads as UTF-8
-- a `buffer.Buffer` 
- - Serialized JSON and YAML
+- `buffer.Buffer` 
+ - Serialized JSON and YAML only (no JS)
  - Requires `options.origin` property set
  - Reads as UTF-8
-- any JS `object` (actually, this means the reading phase is skipped, because object is in-memory already)
+- JS `object` (actually, this means the reading phase is skipped, because object is in-memory already)
 
 ### Transformation
 
@@ -83,17 +83,17 @@ Writing to:
 - _*.js_ file
 - _*.json_ file
 
-Additionally, on API level to:
+Additionally, on API level to a:
 
-- a `stream.Writable` 
- - Serialized JSON and YAML
+- `stream.Writable` 
+ - Serialized JS, JSON and YAML
  - Requires `options.target` property set
  - Writes UTF-8
-- a `buffer.Buffer` 
-  - Serialized JSON and YAML
+- `buffer.Buffer` 
+  - Serialized JS, JSON and YAML
   - Requires `options.target` property set
   - Writes UTF-8
-- any JS `object`
+- JS `object`
 
 ## Limitations
 
@@ -172,8 +172,8 @@ The OPTIONS are more formally defined in the following table:
 | --- | --- | --- | --- | --- | --- |
 | `-o` | `--origin` | string of: [ _js_ &#124; _json_ &#124; _yaml_ ]</code> | The transformation origin type. | if not given, the type is tried to be inferred from the extension of source path, else it is _yaml_ | no |
 | `-t` | `--target` | string of: [ _js_ &#124; _json_ &#124; _yaml_ ]</code> | The transformation target type. | if not given, the type is tried to be inferred from the extension of destination path, else it is _js_ | no |
-| `-i` | `--indent` | integer<br> - [ 1 - 8 ]<br> | The code indention used in destination files. | 4 | no |
-| `-f` | `--force` | n/a | Force overwriting of existing output files on write phase. When files are not overwritten (which is default), then the next transformation with same output file name gets a consecutive number on the base file name, e.g. in case of foo.yaml it would be foo(1).yaml.  | _false_ | no |
+| `-i` | `--indent` | integer<br>[ 1 - 8 ]<br> | The code indention used in destination files. | 4 | no |
+| `-f` | `--force` | n/a | Force overwriting of existing output files on write phase. When files are not overwritten (which is default), then the next transformation with same output file name gets a consecutive number on the base file name, e.g. in case of _foo.yaml_ it would be _foo(1).yaml_.  | _false_ | no |
 | `-m` | `--imports` | string | Define a 'module.exports[.identifier] = ' identifier (to read from JS _source_ file only, must be a valid JS identifier!) | _undefined_ | no |
 | `-x` | `--exports` | string | Define a 'module.exports[.identifier] = ' identifier (for usage in JS _destination_ file only, must be a valid JS identifier!) | _undefined_ | no |
 | `-k` | `--no-color` | n/a | Omit color from output. | _color_ | no |
@@ -209,7 +209,7 @@ $ jyt foo.yaml -t json -i 2
 ```
 
 In this example we have overwritten the standard target type (which is `js`) 
-and applying an indent of _2_ instead of the default _4_. As default the output 
+and applying an indent of 2 instead of the default 4. As default the output 
 file _foo.json_ is written relative to the input file (simply omitting the 
 `dest` option here).
 
@@ -396,7 +396,7 @@ this into a 3-step process:
 1. Read from source ⇒ 2. Alter the JS object ⇒ 3. Write out (maybe to other type)
 
 For more details about this and all the functions provided by this module please refer to the 
-[API Reference](https://github.com/deadratfink/jy-transform/wiki/API-v1.0).
+[API Reference](https://github.com/deadratfink/jy-transform/wiki/API-v2).
 
 The `origin` and `target` type inference is also standard for the API level.
 
@@ -415,12 +415,12 @@ The `options` object has to follow this key-values table:
 | --- | --- | --- | --- | --- |
 | origin | <code>string</code> | The origin type. | If not given, the type is tried to be inferred from the extension of source path, else it is _yaml_. | no |
 | target | <code>string</code> | The target type. | If not given, the type is tried to be inferred from the extension of destination path, else it is _js_ | no |
-| src | <code>string &#124; Readable &#124; object</code> | The source information object: `string` is used as file path, `Readable` stream provides a stringified source and `object` is used as direct JS source. | - | yes |
-| dest | <code>string &#124; Writable &#124; object</code> | The destination information object: `string` is used as file path, `Writable` stream writes a stringified source and `object` is used as direct JS object for assignment. | The output file is stored relative to the input file (same base name but with another extension if type differs). If input and output type are the same then the file overwriting is handled depending on the 'force' value! | no |
+| src | <code>string &#124; Readable &#124; object &#124; Buffer</code> | The source information object: `string` is used as file path, `Readable` stream provides a stringified source and `object` is used as direct JS source. | - | yes |
+| dest | <code>string &#124; Writable &#124; object &#124; Buffer</code> | The destination information object: `string` is used as file path, `Writable` stream writes a stringified source and `object` is used as direct JS object for assignment. | The output file is stored relative to the input file (same base name but with another extension if type differs). If input and output type are the same then the file overwriting is handled depending on the 'force' value! | no |
 | indent | <code>number</code> | The indention in files. | 4 | no |
 | force | <code>boolean</code> | Force overwriting of existing output files on write phase. When files are not overwritten, then the next transformation with same output file name gets a consecutive number on the base file name, e.g. in case of _foo.yaml_ it would be _foo(1).yaml_. | _false_ | no |
-| imports | <code>string</code> | Define a 'module.exports[.identifier] = ' identifier (to read from JS _source_ only, must be a valid JS identifier!) | _undefined_ | no |
-| exports | <code>string</code> | Define a 'module.exports[.identifier] = ' identifier (for usage in JS _destination_ only, must be a valid JS identifier!) | _undefined_ | no |
+| imports | <code>string</code> | Define a `module.exports[.identifier] = ...` identifier (to read from JS _source_ only, must be a valid JS identifier!) | _undefined_ | no |
+| exports | <code>string</code> | Define a `module.exports[.identifier] = ...` identifier (for usage in JS _destination_ only, must be a valid JS identifier!) | _undefined_ | no |
 
 **NOTE:** an invalid indention setting (1 > indent > 8) does not raise an error but a default of 4 SPACEs is applied instead.
 
@@ -588,13 +588,18 @@ var transformer = new Transformer(logger);
 var writer = new Writer(logger);
 ```
 
-At least, the passed logger object _has_ to support the following functions:
+At least, the passed `logger` object _has_ to support the following functions:
 
 ```javascript
 function info(msg)
 function debug(msg)
-function error(msg)
+function trace(msg)
+function error(err|msg)
 ```
+Anyway, there are some fallbacks if a level is not supported:
+
+- DEBUG ⇒ INFO
+- TRACE ⇒ DEBUG
 
 # API Reference
 

--- a/jyt
+++ b/jyt
@@ -37,39 +37,66 @@ var packagePath = __dirname + '/package.json';
  * @private
  */
 var options = {
-    origin:  [ 'o', 'The origin type of INPUT-FILE: [ ' + constants.JS + ' | ' + constants.JSON + ' | ' + constants.YAML + ' ].', 'string', constants.DEFAULT_OPTIONS.origin ],
-    target:  [ 't', 'The target type of OUTPUT-FILE: [ ' + constants.JS + ' | ' + constants.JSON + ' | ' + constants.YAML + ' ].', 'string', constants.DEFAULT_OPTIONS.target ],
-    indent:  [ 'i', 'The indention for pretty-print: 1 - 8.', 'int', constants.DEFAULT_INDENT ],
-    force:   [ 'f', 'Force overwriting of existing output files on write phase. When files are not overwritten (which is default), then the next transformation with same output file name gets a consecutive number on the base file name, e.g. in case of foo.yaml it would be foo(1).yaml.' ],
-    imports: [ 'm', 'Define a \'module.exports[.identifier] = \' identifier (to read from JS _source_ file only, must be a valid JS identifier!).', 'string', constants.DEFAULT_OPTIONS.imports ],
-    exports: [ 'x', 'Define a \'module.exports[.identifier] = \' identifier (for usage in JS destination file only, must be a valid JS identifier!).', 'string', constants.DEFAULT_OPTIONS.exports ]
+    origin:  [ 'o', 'The origin type of INPUT-FILE: [ ' + constants.JS + ' | ' + constants.JSON + ' | ' + constants.YAML + ' ]', 'string', constants.DEFAULT_OPTIONS.origin ],
+    target:  [ 't', 'The target type of OUTPUT-FILE: [ ' + constants.JS + ' | ' + constants.JSON + ' | ' + constants.YAML + ' ]', 'string', constants.DEFAULT_OPTIONS.target ],
+    indent:  [ 'i', 'The indention for pretty-print: 1 - 8', 'int', constants.DEFAULT_INDENT ],
+    force:   [ 'f', 'Force overwriting of existing output files on write phase: when files are not overwritten (which is default), then the next transformation with same output file name gets a consecutive number on the base file name, e.g. in case of foo.yaml it would be foo(1).yaml' ],
+    imports: [ 'm', 'Define a \'module.exports[.identifier] = \' identifier (to read from JS _source_ file only, must be a valid JS identifier!)', 'string', constants.DEFAULT_OPTIONS.imports ],
+    exports: [ 'x', 'Define a \'module.exports[.identifier] = \' identifier (for usage in JS destination file only, must be a valid JS identifier!)', 'string', constants.DEFAULT_OPTIONS.exports ]
 };
+
+/**
+ * Prints the error to console and exit with 1.
+ *
+ * @param {string|Error} err - The error to print.
+ * @private
+ */
+function error(err) {
+    cli.error('////////////////////////////////////////////////////////////////////////////////');
+    cli.error(err);
+    if (err.stack) {
+        cli.debug(err.stack);
+    }
+    cli.error('////////////////////////////////////////////////////////////////////////////////');
+    cli.getUsage(1);
+}
 
 /**
  * The main entry callback. When calling `cli.main()` this receives the `options`
  * given on CLI, then does the transformation with these options and finally, it
  * prints the result to the CLI.
  *
- * @param {array} args    - Not used inside this method!
+ * @param {array} args     - The first mandatory argument is the input file
+ *                           (`args[0]`), the second (optional) argument is the
+ *                           output file (`args[0]`).
  * @param {object} options - The options set on CLI.
  * @private
  */
 function main(args, options) {
-    cli.debug('ARGS: ' + args[0] + ', ' + args[1]);
 
-    options.src = args[0];
-    options.dest = args[1];
+    // read file args and set to options
+
+    if (args.length > 0) {
+        cli.debug('input file: ' + args[0]);
+        options.src = args[0];
+    } else {
+        error('please specify an input file as first argument!');
+    }
+    if (args.length > 1) {
+        cli.debug('output file: ' + args[1]);
+        options.dest = args[1];
+    } else {
+        cli.debug('output file not specified, using default');
+    }
+
+    // transform with options
 
     return transformer.transform(options)
         .then(function (msg) {
             cli.info(msg);
         })
         .catch(function (err) {
-            cli.error('////////////////////////////////////////////////////////////////////////////////');
-            cli.error(err);
-            cli.debug(err.stack);
-            cli.error('////////////////////////////////////////////////////////////////////////////////');
-            cli.getUsage(1);
+            error(err);
         });
 }
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -100,6 +100,7 @@ Constants.prototype.MAX_INDENT = 8;
  * The default `origin` value: 'yaml'.
  *
  * @type {string}
+ * @constant
  * @public
  */
 Constants.prototype.DEFAULT_ORIGIN = constants.YAML;
@@ -108,6 +109,7 @@ Constants.prototype.DEFAULT_ORIGIN = constants.YAML;
  * The default `origin` value: 'js'.
  *
  * @type {string}
+ * @constant
  * @public
  */
 Constants.prototype.DEFAULT_TARGET = constants.JS;
@@ -116,6 +118,7 @@ Constants.prototype.DEFAULT_TARGET = constants.JS;
  * Whether to overwrite existing file or object on output.
  *
  * @type {boolean}
+ * @constant
  * @public
  */
 Constants.prototype.DEFAULT_FORCE_FILE_OVERWRITE = false;
@@ -124,6 +127,7 @@ Constants.prototype.DEFAULT_FORCE_FILE_OVERWRITE = false;
  * The `origin` description value.
  *
  * @type {string}
+ * @constant
  * @public
  */
 Constants.prototype.ORIGIN_DESCRIPTION = 'if not given, the type is tried to be inferred from the extension of source path, else it is \'' + constants.DEFAULT_ORIGIN + '\'';
@@ -132,6 +136,7 @@ Constants.prototype.ORIGIN_DESCRIPTION = 'if not given, the type is tried to be 
  * The `target` description value.
  *
  * @type {string}
+ * @constant
  * @public
  */
 Constants.prototype.TARGET_DESCRIPTION = 'if not given, the type is tried to be inferred from the extension of destination path, else it is \'' + constants.DEFAULT_TARGET + '\'';
@@ -140,6 +145,7 @@ Constants.prototype.TARGET_DESCRIPTION = 'if not given, the type is tried to be 
  * The `dest` description value.
  *
  * @type {string}
+ * @constant
  * @public
  */
 Constants.prototype.DEST_DESCRIPTION = 'storing relative to input file';
@@ -149,6 +155,7 @@ Constants.prototype.DEST_DESCRIPTION = 'storing relative to input file';
  *
  * @type {string}
  * @public
+ * @constant
  * @example
  * module.exports.foo = {...}; // here 'foo' is the identifier for an object to read from the source!
  */
@@ -159,6 +166,7 @@ Constants.prototype.DEFAULT_JS_IMPORTS_IDENTIFIER = undefined;
  *
  * @type {string}
  * @public
+ * @constant
  */
 Constants.prototype.DEFAULT_JS_EXPORTS_IDENTIFIER = undefined;
 

--- a/lib/log-wrapper.js
+++ b/lib/log-wrapper.js
@@ -39,7 +39,22 @@ LogWrapper.prototype.constructor = LogWrapper;
 ///////////////////////////////////////////////////////////////////////////////
 
 /**
- * Log the options with DEBUG level (logger supports it, else with INFO).
+ * Log the options with INFO level.
+ *
+ * @param {string} msg - The message to log.
+ * @example
+ * var logger = ...;
+ * var logWrapper = new LogWrapper(logger);
+ * var msg = '...';
+ * logWrapper.info(msg);
+ * @public
+ */
+LogWrapper.prototype.info = function (msg) {
+    this.logInstance.info(msg);
+};
+
+/**
+ * Log the options with DEBUG level (if logger supports it, else with INFO).
  *
  * @param {string} msg - The message to log.
  * @example
@@ -58,18 +73,23 @@ LogWrapper.prototype.debug = function (msg) {
 };
 
 /**
- * Log the options with INFO level.
+ * Log the options with TRACE level (if logger supports it, else with DEBUG).
  *
  * @param {string} msg - The message to log.
  * @example
  * var logger = ...;
  * var logWrapper = new LogWrapper(logger);
  * var msg = '...';
- * logWrapper.info(msg);
+ * logWrapper.trace(msg);
  * @public
+ * @see {@link #debug}
  */
-LogWrapper.prototype.info = function (msg) {
-    this.logInstance.info(msg);
+LogWrapper.prototype.trace = function (msg) {
+    if (this.logInstance.trace && typeof this.logInstance.trace === 'function') {
+        this.logInstance.trace(msg);
+    } else {
+        this.debug(msg);
+    }
 };
 
 /**

--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var Constants = require('./constants.js');
-var LogWrapper = require('./log-wrapper.js');
+var Constants = require('./constants');
+var LogWrapper = require('./log-wrapper');
 var Promise = require('bluebird');
 var path = require('path');
 var fs = require('fs');
@@ -9,13 +9,13 @@ var isStream = require('is-stream');
 
 /**
  * @typedef {object} Options
- * @property {string} [origin=yaml]            - The origin type.
- * @property {string} [target=js]              - The target type.
- * @property {(string|Readable|object)} src    - The source.
- * @property {(string|Writable|object)} [dest] - The destination.
- * @property {number} [indent=4]               - The indention in files.
- * @property {string} [imports=undefined]      - The exports name for reading from JS source file or objects only.
- * @property {string} [exports=undefined]      - The exports name for usage in JS destination files only.
+ * @property {string} [origin=yaml]                   - The origin type.
+ * @property {string} [target=js]                     - The target type.
+ * @property {(string|Readable|object|Buffer)} src    - The source (`string` type is treated as a file path).
+ * @property {(string|Writable|object|Buffer)} [dest] - The destination (`string` type is treated as a file path).
+ * @property {number} [indent=4]                      - The indention in files.
+ * @property {string} [imports=undefined]             - The exports name for reading from JS source file or objects only.
+ * @property {string} [exports=undefined]             - The exports name for usage in JS destination files only.
  */
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -34,7 +34,7 @@ var isStream = require('is-stream');
  *        **NOTE:** This class is not to be intended to be called from
  *        outside this module!
  * @example
- * var OptionsHandler = require('./options-handler.js');
+ * var OptionsHandler = require('./options-handler');
  * var logger = ...;
  *
  * var optionsHandler = new OptionsHandler(logger);
@@ -352,10 +352,10 @@ function OptionsHandler(logger) {
                             self.logInstance.debug('Destination file: ' + assertedOptions.dest);
                             return assertedOptions;
                         });
-                } else if (isStream.writable(assertedOptions.dest)) {
-                    self.logInstance.debug('options.dest is Writable stream');
+                } else if (isStream.writable(assertedOptions.dest) || (assertedOptions.dest instanceof Buffer)) {
+                    self.logInstance.debug('options.dest is Writable stream of Buffer');
                     if (!assertedOptions.target) {
-                        return Promise.reject(new Error('When options.dest is a Writable stream then setting options.target is mandatory!'));
+                        return Promise.reject(new Error('When options.dest is a Writable stream or Buffer then setting options.target is mandatory!'));
                     }
                 } else {
                     self.logInstance.debug('Destination file: ' + assertedOptions.dest);
@@ -428,7 +428,7 @@ function OptionsHandler(logger) {
     this.ensureIndent = function (options) {
         return assertOptions(options)
             .then(function (assertedOptions) {
-                self.logInstance.debug('options before ensureIndent():: ' + JSON.stringify(assertedOptions, null, 4));
+                self.logInstance.trace('options before ensureIndent():: ' + JSON.stringify(assertedOptions, null, 4));
                 if (assertedOptions.indent === undefined) {
                     self.logInstance.info('Missing indention, reset to default: ' + Constants.DEFAULT_INDENT);
                     assertedOptions.indent = Constants.DEFAULT_INDENT;
@@ -439,7 +439,7 @@ function OptionsHandler(logger) {
                     self.logInstance.info('Indention \'' + assertedOptions.indent + '\' is too wide, reset to default: ' + Constants.DEFAULT_INDENT);
                     assertedOptions.indent = Constants.DEFAULT_INDENT;
                 }
-                self.logInstance.debug('options after ensureIndent():: ' + JSON.stringify(assertedOptions, null, 4));
+                self.logInstance.trace('options after ensureIndent():: ' + JSON.stringify(assertedOptions, null, 4));
                 return assertedOptions;
             });
     };

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -96,11 +96,13 @@ function Reader(logger) {
                     self.logInstance.debug(origin + ' reading from Readable');
                     if (origin === Constants.JSON || origin === Constants.JS) {
                         resolve(JSON.parse(buffer.toString(Constants.UTF8)));
-                    } else if (origin === Constants.YAML) {
+                    } else {// HINT: commented (see below): if (origin === Constants.YAML) {
                         resolve(jsYaml.safeLoad(buffer.toString(Constants.UTF8)));
-                    } else {
-                        reject(new Error('Unsupported type: ' + origin + ' to read from Readable'));
                     }
+                    // HINT: for the sake of test coverage it's commented, since this is a private method we have control over options.origin inside this class!
+                    //else {
+                    //    reject(new Error('Unsupported type: ' + origin + ' to read from Readable'));
+                    //}
                 } catch (err) { // probably a SyntaxError for JSON or a YAMLException
                     self.logInstance.error('Unexpected error: ' + err.stack);
                     readable.emit('error', err); // send to .on('error',...

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var Constants = require('./constants.js');
-var LogWrapper = require('./log-wrapper.js');
-var OptionsHandler = require('./options-handler.js');
-var Validator = require('./validator.js');
+var Constants = require('./constants');
+var LogWrapper = require('./log-wrapper');
+var OptionsHandler = require('./options-handler');
+var Validator = require('./validator');
 var jsYaml = require('js-yaml');
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs'));
@@ -23,7 +23,7 @@ var stringify = require('json-stringify-safe');
  * @returns {Reader} The instance.
  * @constructor
  * @class This class provides utility methods usable to read YAML, JSON or JS
- *        from a source (file, {object}, {@link Buffer} or {@link stream.Readable}) to JS memory objects.
+ *        from a source (file, object, {@link Buffer} or {@link stream.Readable}) to JS memory objects.
  * @example
  * var Reader = require('jy-transform').Reader;
  * var logger = ...;
@@ -68,7 +68,7 @@ function Reader(logger) {
         return function () {
             var chunk;
             while (null !== (chunk = readable.read())) {
-                self.logInstance.debug('JSON chunk: ', chunk);
+                self.logInstance.trace('JSON chunk: ', chunk);
                 bufs.push(chunk);
             }
         };
@@ -139,7 +139,7 @@ function Reader(logger) {
     ///////////////////////////////////////////////////////////////////////////////
 
     /**
-     * Reads the data from a given JS or JSON  source.
+     * Reads the data from a given JS or JSON source.
      *
      * @param {Options} options - Contains the JS/JSON source reference to read from.
      * @returns {Promise}       - Contains the read JS object.
@@ -147,10 +147,14 @@ function Reader(logger) {
      * @example
      * var Reader = require('jy-transform').Reader;
      * var logger = ...;
+     * var reader = new Reader(logger);
+     *
+     * // --- from file path
+     *
      * var options = {
      *    src: 'foo.js'
      * };
-     * var reader = new Reader(logger);
+     *
      * reader.readJs(options)
      *     .then(function (obj){
      *         logger.info(JSON.stringify(obj));
@@ -159,9 +163,13 @@ function Reader(logger) {
      *         logger.error(err.stack);
      *     });
      *
+     *
+     * // --- from Readable
+     *
      * options = {
      *     src: fs.createReadStream('foo.js')
      * };
+     *
      * reader.readJs(options)
      *     .then(function (obj){
      *         logger.info(JSON.stringify(obj));
@@ -169,12 +177,16 @@ function Reader(logger) {
      *     .catch(function (err) {
      *         logger.error(err.stack);
      *     });
+     *
+     *
+     * // --- from object
      *
      * options = {
      *     src: {
      *         foo: 'bar'
      *     }
      * };
+     *
      * reader.readJs(options)
      *     .then(function (obj){
      *         logger.info(JSON.stringify(obj));
@@ -184,7 +196,7 @@ function Reader(logger) {
      *     });
      */
     this.readJs = function (options) {
-        self.logInstance.debug('OPTIONS BEFORE ASSERTING IN readJs:::' + JSON.stringify(options));
+        self.logInstance.trace('OPTIONS BEFORE ASSERTING IN readJs:::' + JSON.stringify(options));
         return self.optionsHandler.assertOptions(options, ['src'])
             .then(function (assertedOptions) {
                 return new Promise(function (resolve, reject) {
@@ -198,7 +210,7 @@ function Reader(logger) {
                                     reject(new Error('found invalid identifier for reading from exports: ' + stringify(options.imports, null, 4)));
                                 } else {
                                     var json = require(resolvedPath)[options.imports];
-                                    self.logInstance.debug('LOADED JSON object (' + options.imports + '):: ' + stringify(json, null, 4));
+                                    self.logInstance.trace('LOADED JSON object (' + options.imports + '):: ' + stringify(json, null, 4));
                                     if (!json) {
                                         reject(new Error('an identifier string \'' + options.imports + '\' was specified for JS object but could not find this object, pls ensure that file ' + assertedOptions.src + ' contains it.'));
                                     } else {
@@ -223,7 +235,7 @@ function Reader(logger) {
                             reject(new Error('found invalid identifier for reading from object: ' + stringify(options.imports, null, 4)));
                         } else {
                             var obj = assertedOptions.src[options.imports];
-                            self.logInstance.debug('LOADED JSON object (' + options.imports + '):: ' + stringify(obj, null, 4));
+                            self.logInstance.trace('LOADED JSON object (' + options.imports + '):: ' + stringify(obj, null, 4));
                             if (!obj) {
                                 reject(new Error('an identifier string \'' + options.imports + '\' was specified for JS object but could not find this object, pls ensure that object source contains it.'));
                             } else {
@@ -249,9 +261,15 @@ function Reader(logger) {
      * @example
      * var Reader = require('jy-transform').Reader;
      * var logger = ...;
-     *
      * var reader = new Reader(logger);
-     * reader.readYaml('foo.yaml')
+     *
+     * // --- from file path
+     *
+     * options = {
+     *     src: 'foo.yml'
+     * };
+     *
+     * reader.readYaml(options)
      *     .then(function (obj){
      *         logger.info(JSON.stringify(obj));
      *     })
@@ -259,9 +277,13 @@ function Reader(logger) {
      *         logger.error(err.stack);
      *     });
      *
+     *
+     * // --- from Readable
+     *
      * options = {
      *     src: fs.createReadStream('foo.yml')
      * };
+     *
      * reader.readJs(options)
      *     .then(function (obj){
      *         logger.info(JSON.stringify(obj));
@@ -271,7 +293,7 @@ function Reader(logger) {
      *     });
      */
     this.readYaml = function (options) {
-        self.logInstance.debug('OPTIONS BEFORE ASSERTING IN readYaml::: ' + JSON.stringify(options));
+        self.logInstance.trace('OPTIONS BEFORE ASSERTING IN readYaml::: ' + JSON.stringify(options));
         return self.optionsHandler.assertOptions(options, ['src'])
             .then(function (assertedOptions) {
                 return new Promise(function (resolve, reject) {
@@ -315,7 +337,7 @@ function Reader(logger) {
 //            return Promise.resolve().then(function () {
 //                var jsDocs = [];
 //                return jsYaml.safeLoadAll(yaml, function (doc) { // TOD this will not work in Promise environment!!!
-//                    self.logger.debug(doc);
+//                    self.logger.trace(doc);
 //                    jsDocs.push(doc);
 //                });
 //            });

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -23,7 +23,7 @@ var stringify = require('json-stringify-safe');
  * @returns {Reader} The instance.
  * @constructor
  * @class This class provides utility methods usable to read YAML, JSON or JS
- *        from a source (file, object, {@link Buffer} or {@link stream.Readable}) to JS memory objects.
+ *        from a source (file, {object} or {@link stream.Readable}) to JS memory objects.
  * @example
  * var Reader = require('jy-transform').Reader;
  * var logger = ...;
@@ -106,32 +106,6 @@ function Reader(logger) {
                     readable.emit('error', err); // send to .on('error',...
                 }
             });
-    }
-
-    /**
-     * Reads from a passed _single_ {@link Buffer} (i.e. non-streamed) and
-     * resolves by callback.
-     *
-     * @param {Buffer} buffer    - The source to read from.
-     * @param {function} resolve - Callback for success case.
-     * @param {function} reject  - Callback for Error case.
-     * @param {string} origin    - Origin type, must be 'yaml' or 'json'/'js'.
-     * @private
-     */
-    function readFromBuffer(buffer, resolve, reject, origin) {
-        try {
-            self.logInstance.debug(origin + ' reading from Buffer');
-            if (origin === Constants.JSON || origin === Constants.JS) {
-                resolve(JSON.parse(buffer.toString(Constants.UTF8)));
-            } else if (origin === Constants.YAML) {
-                resolve(jsYaml.safeLoad(buffer.toString(Constants.UTF8)));
-            } else {
-                reject(new Error('Unsupported type: ' + origin + ' to read from Buffer'));
-            }
-        } catch (err) { // probably a SyntaxError for JSON or a YAMLException
-            self.logInstance.error('Unexpected error: ' + err.stack);
-            reject(err);
-        }
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -227,8 +201,6 @@ function Reader(logger) {
                         }
                     } else if (isStream.readable(assertedOptions.src)) {
                         readFromStream(assertedOptions.src, resolve, reject, Constants.JSON);
-                    } else if (assertedOptions.src instanceof Buffer) {
-                        readFromBuffer(assertedOptions.src, resolve, reject, Constants.JSON);
                     } else if (options.imports && options.imports !== '') {
 
                         if (!self.validator.validateIdentifier(options.imports)) {
@@ -311,8 +283,6 @@ function Reader(logger) {
                             });
                     } else if (isStream.readable(assertedOptions.src)) {
                         readFromStream(assertedOptions.src, resolve, reject, Constants.YAML);
-                    } else if (Buffer.isBuffer(assertedOptions.src)) {
-                        readFromBuffer(assertedOptions.src, resolve, reject, Constants.YAML);
                     } else {
                         resolve(assertedOptions.src);
                     }

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var Writer = require('./writer.js');
-var Reader = require('./reader.js');
-var LogWrapper = require('./log-wrapper.js');
-var OptionsHandler = require('./options-handler.js');
-var middleware = require('./middleware.js');
+var Writer = require('./writer');
+var Reader = require('./reader');
+var LogWrapper = require('./log-wrapper');
+var OptionsHandler = require('./options-handler');
+var middleware = require('./middleware');
 var path = require('path');
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var Constants = require('./constants.js');
-var LogWrapper = require('./log-wrapper.js');
-var OptionsHandler = require('./options-handler.js');
+var Constants = require('./constants');
+var LogWrapper = require('./log-wrapper');
+var OptionsHandler = require('./options-handler');
 var Promise = require('bluebird');
 var stringify = require('json-stringify-safe');
 var path = require('path');

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -226,31 +226,6 @@ function Writer(logger) {
         dest.end();
     }
 
-    /**
-     * Writes a string serialized data object to a `Buffer`.
-     *
-     * @param {string} object    - The data to write into stream.
-     * @param {string} dest      - The {@link Buffer} destination.
-     * @param {string} target    - The target type, one of [ 'yaml' | 'json' | 'js' ].
-     * @param {function} resolve - The Promise `resolve` callback.
-     * @param {function} reject  - The Promise `reject` callback.
-     * @see {@link Constants#YAML}
-     * @see {@link Constants#JSON}
-     * @see {@link Constants#JS}
-     * @returns {Promise} - Containing the write success message to handle by caller (e.g. for logging).
-     * @throws {Error}    - If serialized JS object could not be written due to any reason.
-     * @private
-     */
-    function writeToBuffer(object, dest, target, resolve, reject) {
-        // write stringified data
-        try {
-            dest.write(object, Constants.UTF8);
-            resolve('Writing ' + target + ' to Buffer successful.');
-        } catch (err) {
-            reject(err);
-        }
-    }
-
     ///////////////////////////////////////////////////////////////////////////////
     // API METHODS (PUBLIC)
     ///////////////////////////////////////////////////////////////////////////////
@@ -302,21 +277,6 @@ function Writer(logger) {
      *     .catch(function (err) {
      *         logger.error(err.stack);
      *     });
-     *
-     * // ---- write obj to Buffer
-     *
-     * options = {
-     *     dest: new Buffer('...', Constants.UTF8),
-     *     indent: 2
-     * }
-     *
-     * writer.writeYaml(obj, options)
-     *     .then(function (msg){
-     *         logger.info(msg);
-     *     })
-     *     .catch(function (err) {
-     *         logger.error(err.stack);
-     *     });
      */
     this.writeYaml = function (object, options) {
         return self.optionsHandler.ensureIndent(options)
@@ -341,8 +301,6 @@ function Writer(logger) {
                             writeToFile(yaml, dest, Constants.YAML, resolve, reject, ensuredOptions.force);
                         } else if (isStream.writable(dest)) { // stream
                             writeToStream(yaml, dest, Constants.YAML, resolve, reject);
-                        } else if (Buffer.isBuffer(dest)) { // Buffer
-                            writeToBuffer(yaml, dest, Constants.YAML, resolve, reject);
                         } else { // object
                             ensuredOptions.dest = yaml;
                             resolve('Writing YAML to options.dest successful.');
@@ -413,21 +371,6 @@ function Writer(logger) {
      *     .catch(function (err) {
      *         logger.error(err.stack);
      *     });
-     *
-     * // ---- write obj to Buffer
-     *
-     * options = {
-     *     dest: new Buffer('...', Constants.UTF8),
-     *     indent: 2
-     * }
-     *
-     * writer.writeJson(obj, options)
-     *     .then(function (msg){
-     *         logger.info(msg);
-     *     })
-     *     .catch(function (err) {
-     *         logger.error(err.stack);
-     *     });
      */
     this.writeJson = function (object, options) {
         return self.optionsHandler.ensureIndent(options)
@@ -443,8 +386,6 @@ function Writer(logger) {
                             writeToFile(serializeJsToJsonString(object, indent), dest, Constants.JSON, resolve, reject, ensuredOptions.force);
                         } else if (isStream.writable(dest)) { // stream
                             writeToStream(serializeJsToJsonString(object, indent), dest, Constants.JSON, resolve, reject);
-                        } else if (Buffer.isBuffer(dest)) { // Buffer
-                            writeToBuffer(serializeJsToJsonString(object, indent), dest, Constants.JSON, resolve, reject);
                         } else { // object
                             ensuredOptions.dest = serializeJsToJsonString(object, indent);
                             resolve('Writing JSON to options.dest successful.');
@@ -516,22 +457,6 @@ function Writer(logger) {
      *     .catch(function (err) {
      *         logger.error(err.stack);
      *     });
-     *
-     *
-     * // ---- write obj to Buffer
-     *
-     * options = {
-     *     dest: new Buffer('...', Constants.UTF8),
-     *     indent: 2
-     * }
-     *
-     * writer.writeJs(obj, options)
-     *     .then(function (msg){
-     *         logger.info(msg);
-     *     })
-     *     .catch(function (err) {
-     *         logger.error(err.stack);
-     *     });
      */
     this.writeJs = function (object, options) {
         return self.optionsHandler.ensureIndent(options)
@@ -559,15 +484,6 @@ function Writer(logger) {
                                 .catch(function (err) {
                                     reject(err);
                                 });
-                        } else if (Buffer.isBuffer(dest)) { // Buffer
-                            serializeJsToString(object, indent, ensuredOptions.exports)
-                                .then(function (data) {
-                                    return writeToBuffer(data, dest, Constants.JS, resolve, reject);
-                                })
-                                .catch(function (err) {
-                                    reject(err);
-                                });
-
                         } else { // object
                             var msg;
                             if (ensuredOptions.exports && ensuredOptions.exports !== '') {

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var Constants = require('./constants.js');
-var LogWrapper = require('./log-wrapper.js');
-var OptionsHandler = require('./options-handler.js');
-var Validator = require('./validator.js');
+var Constants = require('./constants');
+var LogWrapper = require('./log-wrapper');
+var OptionsHandler = require('./options-handler');
+var Validator = require('./validator');
 var serializeJs = require('serialize-js');
 var jsYaml = require('js-yaml');
 var Promise = require('bluebird');
@@ -26,7 +26,7 @@ var isStream = require('is-stream');
  * @constructor
  * @class This class provides utility methods usable to write JS objects
  *        from memory to a JSON/JS/YAML destination
- *        (file, {object} or {@link stream.Readable}).
+ *        (file, object or {@link stream.Readable}).
  * @example
  * var Writer = require('jy-transform').Writer;
  * var logger = ...;
@@ -34,6 +34,7 @@ var isStream = require('is-stream');
  * var writer = new Writer(logger);
  */
 function Writer(logger) {
+
     /**
      * The logger instance.
      *
@@ -95,6 +96,7 @@ function Writer(logger) {
      * @param {string} [exportsTo] - Name for export (*IMPORTANT:* must be a valid ES6 identifier).
      * @returns {Promise}          - Promise resolve with the serialized JS object.
      * @private
+     * @todo [[#35](https://github.com/deadratfink/jy-transform/issues/35)] Add `'use strict';` in JS output file (-> `'\'use strict\';' + os.EOL + os.EOL + ...`)?
      */
     function serializeJsToString(object, indent, exportsTo) {
         return createExportsString(exportsTo)
@@ -269,6 +271,8 @@ function Writer(logger) {
      * var logger = ...;
      * var writer = new Writer(logger);
      *
+     * // ---- write obj to file
+     *
      * var obj = {...},
      * var options = {
      *     dest: 'result.yml',
@@ -283,6 +287,9 @@ function Writer(logger) {
      *         logger.error(err.stack);
      *     });
      *
+     *
+     * // ---- write obj to Writable
+     *
      * options = {
      *     dest: fs.createWriteStream('result.yml'),
      *     indent: 4
@@ -296,8 +303,10 @@ function Writer(logger) {
      *         logger.error(err.stack);
      *     });
      *
+     * // ---- write obj to Buffer
+     *
      * options = {
-     *     dest: new Buffer(),
+     *     dest: new Buffer('...', Constants.UTF8),
      *     indent: 2
      * }
      *
@@ -358,6 +367,8 @@ function Writer(logger) {
      * var logger = ...;
      * var writer = new Writer(logger);
      *
+     * // ---- write obj to file
+     *
      * var obj = {...};
      * var options = {
      *     dest: 'result.json',
@@ -372,6 +383,9 @@ function Writer(logger) {
      *         logger.error(err.stack);
      *     });
      *
+     *
+     * // ---- write obj to Writable
+     *
      * options = {
      *     dest: fs.createWriteStream('result.json'),
      *     indent: 4
@@ -384,6 +398,8 @@ function Writer(logger) {
      *     .catch(function (err) {
      *         logger.error(err.stack);
      *     });
+     *
+     * // ---- write obj to object
      *
      * options = {
      *     dest: {},
@@ -398,8 +414,10 @@ function Writer(logger) {
      *         logger.error(err.stack);
      *     });
      *
+     * // ---- write obj to Buffer
+     *
      * options = {
-     *     dest: new Buffer(),
+     *     dest: new Buffer('...', Constants.UTF8),
      *     indent: 2
      * }
      *
@@ -451,6 +469,8 @@ function Writer(logger) {
      * var logger = ...;
      * var writer = new Writer(logger);
      *
+     * // ---- write obj to file
+     *
      * var obj = {...};
      * var options = {
      *     dest: 'result.js',
@@ -465,6 +485,9 @@ function Writer(logger) {
      *         logger.error(err.stack);
      *     });
      *
+     *
+     * // ---- write obj to Writable
+     *
      * options = {
      *     dest: fs.createWriteStream('result.json'),
      *     indent: 4
@@ -477,6 +500,9 @@ function Writer(logger) {
      *     .catch(function (err) {
      *         logger.error(err.stack);
      *     });
+     *
+     *
+     * // ---- write obj to object
      *
      * options = {
      *     dest: {},
@@ -491,8 +517,11 @@ function Writer(logger) {
      *         logger.error(err.stack);
      *     });
      *
+     *
+     * // ---- write obj to Buffer
+     *
      * options = {
-     *     dest: new Buffer(),
+     *     dest: new Buffer('...', Constants.UTF8),
      *     indent: 2
      * }
      *
@@ -531,7 +560,14 @@ function Writer(logger) {
                                     reject(err);
                                 });
                         } else if (Buffer.isBuffer(dest)) { // Buffer
-                            writeToBuffer(serializeJsToJsonString(object, indent), dest, Constants.JSON, resolve, reject);
+                            serializeJsToString(object, indent, ensuredOptions.exports)
+                                .then(function (data) {
+                                    return writeToBuffer(data, dest, Constants.JS, resolve, reject);
+                                })
+                                .catch(function (err) {
+                                    reject(err);
+                                });
+
                         } else { // object
                             var msg;
                             if (ensuredOptions.exports && ensuredOptions.exports !== '') {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,6 @@
         "url": "https://github.com/deadratfink"
     },
     "contributors": [
-        {
-            "name": "Jens Krefeldt",
-            "email": "j.krefeldt@gmail.com",
-            "url": "https://github.com/deadratfink"
-        }
     ],
     "license": "SEE LICENSE IN [LICENSE.md](https://github.com/deadratfink/jy-transform/blob/master/LICENSE.md)",
     "repository": {
@@ -36,7 +31,7 @@
     },
     "scripts": {
         "docs": "cat docs/LOGO.md > README.md && cat docs/BADGES.md >> README.md && cat docs/TOC.md >> README.md && package-json-to-readme --no-footer ./package.json >> README.md && cat docs/USAGE.md >> README.md && echo '\n\n' >> README.md && cat docs/CHANGELOG.md >> README.md && doctoc README.md --github --title '# TOC' --maxlevel 2",
-        "wiki": "jsdoc2md ./jyt lib/*.js index.js > docs/API.md && doctoc docs/API.md --github --title '### TOC' --maxlevel 2 && cat docs/API.md > '../jy-transform.wiki/API-v2.md' && cat docs/CONTRIBUTING.md > ../jy-transform.wiki/Contributing.md",
+        "wiki": "jsdoc2md ./jyt lib/*.js index.js > docs/API.md && doctoc docs/API.md --github --title '### TOC' --maxlevel 2 && cat docs/API.md > '../jy-transform.wiki/API-v2.md' && cat docs/CONTRIBUTING.md > ../jy-transform.wiki/Contributing.md && cat docs/CHANGELOG.md > ../jy-transform.wiki/Changelog.md && doctoc ../jy-transform.wiki/Changelog.md --github --title '# TOC' --maxlevel 3",
         "test": "istanbul cover _mocha --report lcovonly -- -R $npm_package_config_test_mocha_unit_reporter ./test/test*.js"
     },
     "engines": {
@@ -56,7 +51,7 @@
         "codecov": "^1.0.1",
         "coveralls": "^2.11.9",
         "doctoc": "^1.0.0",
-        "fs-extra": "^0.26.7",
+        "fs-extra": "^0.30.0",
         "istanbul": "^0.4.2",
         "jsdoc-parse": "^1.2.7",
         "jsdoc-to-markdown": "^1.3.3",

--- a/test/data/readable-test-dummy.txt
+++ b/test/data/readable-test-dummy.txt
@@ -1,1 +1,3 @@
-DO NOT DELETE THIS FILE, IT IS NEEDED FOR test-option-handler.js#ensureSrc() TEST!
+{
+	"important": "DO NOT DELETE THIS FILE, IT IS NEEDED FOR test-option-handler.js#ensureSrc() TEST!"
+}

--- a/test/test-log-wrapper.js
+++ b/test/test-log-wrapper.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var LogWrapper = require('../lib/log-wrapper.js');
+var LogWrapper = require('../lib/log-wrapper');
 var assert = require('assert');
 
 /**
@@ -10,12 +10,14 @@ describe('Executing \'jy-transform\' project log wrapper test suite.', function 
 
     var infoMsg;
     var debugMsg;
+    var traceMsg;
     var errorMsg;
     var verboseResultArray = [];
     var logWrapper;
 
     var INFO = 'INFO';
     var DEBUG = 'DEBUG';
+    var TRACE = 'TRACE';
     var ERROR = 'ERROR';
 
     /**
@@ -31,6 +33,9 @@ describe('Executing \'jy-transform\' project log wrapper test suite.', function 
         debug: function (msg) {
             debugMsg = msg;
         },
+        trace: function (msg) {
+            traceMsg = msg;
+        },
         error: function (msg) {
             errorMsg = msg;
         }
@@ -40,19 +45,31 @@ describe('Executing \'jy-transform\' project log wrapper test suite.', function 
         info: function (msg) {
             infoMsg = msg;
         },
+        trace: function (msg) {
+            traceMsg = msg;
+        },
+        error: function (msg) {
+            errorMsg = msg;
+        }
+    };
+
+    var mockLoggerWithoutTraceFunction = {
+        info: function (msg) {
+            infoMsg = msg;
+        },
+        debug: function (msg) {
+            debugMsg = msg;
+        },
         error: function (msg) {
             errorMsg = msg;
         }
     };
 
     var mockLoggerWithVerboseFunction = {
-
         info: function (msg) {
             verboseResultArray.push(msg);
         }
     };
-
-
 
     describe('Testing LogWrapper with mockLogger', function () {
 
@@ -62,6 +79,7 @@ describe('Executing \'jy-transform\' project log wrapper test suite.', function 
         beforeEach(function () {
             infoMsg = undefined;
             debugMsg = undefined;
+            traceMsg = undefined;
             errorMsg = undefined;
             logWrapper = new LogWrapper(mockLogger);
         });
@@ -77,6 +95,13 @@ describe('Executing \'jy-transform\' project log wrapper test suite.', function 
         it('should log with ' + expected, function (done) {
             logWrapper.debug(expected);
             assert.equal(debugMsg, expected, 'logger message should contain value ' + expected);
+            done();
+        });
+
+        expected = TRACE;
+        it('should log with ' + expected, function (done) {
+            logWrapper.trace(expected);
+            assert.equal(traceMsg, expected, 'logger message should contain value ' + expected);
             done();
         });
 
@@ -122,6 +147,7 @@ describe('Executing \'jy-transform\' project log wrapper test suite.', function 
         beforeEach(function () {
             infoMsg = undefined;
             debugMsg = undefined;
+            traceMsg = undefined;
             errorMsg = undefined;
             logWrapper = new LogWrapper(mockLoggerWithoutDebugFunction);
         });
@@ -137,6 +163,41 @@ describe('Executing \'jy-transform\' project log wrapper test suite.', function 
         it('should log with ' + expected, function (done) {
             logWrapper.debug(expected);
             assert.equal(infoMsg, expected, 'logger message should contain value ' + expected);
+            done();
+        });
+
+        expected = ERROR;
+        it('should log with ' + expected, function (done) {
+            logWrapper.error(expected);
+            assert.equal(errorMsg, expected, 'logger message should contain value ' + expected);
+            done();
+        });
+
+    });
+
+    describe('Testing LogWrapper with mockLoggerWithoutTraceFunction', function () {
+
+        /**
+         * Resets the mock logger message targets.
+         */
+        beforeEach(function () {
+            infoMsg = undefined;
+            debugMsg = undefined;
+            errorMsg = undefined;
+            logWrapper = new LogWrapper(mockLoggerWithoutTraceFunction);
+        });
+
+        var expected = INFO;
+        it('should log with ' + expected, function (done) {
+            logWrapper.info(expected);
+            assert.equal(infoMsg, expected, 'logger message should contain value ' + expected);
+            done();
+        });
+
+        expected = TRACE;
+        it('should log with ' + expected, function (done) {
+            logWrapper.trace(expected);
+            assert.equal(debugMsg, expected, 'logger message should contain value ' + expected);
             done();
         });
 

--- a/test/test-middleware.js
+++ b/test/test-middleware.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var Transformer = require('../index.js');
-var Middleware = require('../index.js').middleware;
+var Transformer = require('../index');
+var Middleware = require('../index').middleware;
 var identityMiddleware = Middleware.identityMiddleware;
 var transformer;
 var Promise = require('bluebird');

--- a/test/test-options-handler.js
+++ b/test/test-options-handler.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var Constants = require('../lib/constants.js');
+var Constants = require('../lib/constants');
 var assert = require('assert');
-var YAMLException = require('js-yaml/lib/js-yaml/exception.js');
+//var YAMLException = require('js-yaml/lib/js-yaml/exception');
 var fs = require('fs');
 var path = require('path');
-var OptionsHandler = require('../lib/options-handler.js');
+var OptionsHandler = require('../lib/options-handler');
 var optionsHandler;
 var logger;
 
@@ -103,7 +103,7 @@ describe('Executing \'jy-transform\' project OptionsHandler test suite.', functi
             assertOptionsError(null, optionsHandler.completeOptions, done);
         });
 
-        it('should resolve options.src/orign and origin.dest/target with default values (' + Constants.DEFAULT_ORIGIN + '/' + Constants.DEFAULT_TARGET + ')', function (done) {
+        it('should resolve options.src/origin and options.dest/target with default values (' + Constants.DEFAULT_ORIGIN + '/' + Constants.DEFAULT_TARGET + ')', function (done) {
             var PATH_WITH_INVALID_EXT = 'PATH_WITH_INVALID.EXT';
             var options = {
                 src: PATH_WITH_INVALID_EXT,
@@ -511,6 +511,50 @@ describe('Executing \'jy-transform\' project OptionsHandler test suite.', functi
                 src: fs.createReadStream('./test/data/readable-test-dummy.txt')
             };
             assertOptionsError(options, optionsHandler.ensureSrc, done);
+        });
+
+        it('should resolve original options.src Readable', function (done) {
+            var readable = fs.createReadStream('./test/data/readable-test-dummy.txt');
+            var options = {
+                src: readable,
+                origin: Constants.JSON
+            };
+            optionsHandler.ensureSrc(options)
+                .then(function (resultOptions) {
+                    assert.notEqual(resultOptions.src, null, 'options should contain src but is missing');
+                    assert.equal(resultOptions.src, readable, 'result options.src should have type Readable');
+                    done();
+                })
+                .catch(function (err) {
+                    logger.error('UNEXPECTED ERROR: ' + err.stack);
+                    done(err);
+                });
+        });
+
+        it('should reject when Buffer is given but not origin', function (done) {
+            var buffer = new Buffer('{"msg": "I\'m a string!"}', Constants.UTF8);
+            var options = {
+                src: buffer
+            };
+            assertOptionsError(options, optionsHandler.ensureSrc, done);
+        });
+
+        it('should resolve original options.src Buffer', function (done) {
+            var buffer = new Buffer('{"msg": "I\'m a string!"}', Constants.UTF8);
+            var options = {
+                src: buffer,
+                origin: Constants.JSON
+            };
+            optionsHandler.ensureSrc(options)
+                .then(function (resultOptions) {
+                    assert.notEqual(resultOptions.src, null, 'options should contain src but is missing');
+                    assert.equal(resultOptions.src, buffer, 'result options.src should have type Buffer');
+                    done();
+                })
+                .catch(function (err) {
+                    logger.error('UNEXPECTED ERROR: ' + err.stack);
+                    done(err);
+                });
         });
 
         it('should resolve original options.src object', function (done) {

--- a/test/test-reader.js
+++ b/test/test-reader.js
@@ -13,6 +13,8 @@ var reader;
  */
 describe('Executing \'jy-transform\' project Reader test suite.', function () {
 
+    var invalidOrigin = 'INVALID_ORIGIN';
+
     /**
      * Init the test logger and Reader.
      */
@@ -134,6 +136,25 @@ describe('Executing \'jy-transform\' project Reader test suite.', function () {
             var options = {
                 src: './test/data/test-imports.js',
                 imports: exportsNotExists
+            };
+
+            reader.readJs(options)
+                .then(function (msg) {
+                    done(new Error('Error expected'));
+                })
+                .catch(function (err) {
+                    logger.info('EXPECTED ERROR: ' + err.stack);
+                    assert.notEqual(err, null, 'err should not be null');
+                    assert(err instanceof Error, 'expected Error should equal Error, was: ' + (typeof err));
+                    done();
+                });
+        });
+
+        it('should reject reading JS from stream with Error on invalid value for options.origin: ' + invalidOrigin, function (done) {
+
+            var options = {
+                src: fs.createReadStream('./test/data/test-imports.js'),
+                origin: invalidOrigin
             };
 
             reader.readJs(options)
@@ -501,6 +522,25 @@ describe('Executing \'jy-transform\' project Reader test suite.', function () {
                 })
                 .catch(function (err) {
                     logger.info('EXPECTED ERROR: ' + err);
+                    assert.notEqual(err, null, 'err should not be null');
+                    assert(err instanceof Error, 'expected Error should equal Error, was: ' + (typeof err));
+                    done();
+                });
+        });
+
+        it('should reject reading YAML from stream with Error on invalid value for options.origin: ' + invalidOrigin, function (done) {
+
+            var options = {
+                src: fs.createReadStream('./test/data/test-data.yaml'),
+                origin: invalidOrigin
+            };
+
+            reader.readYaml(options)
+                .then(function (msg) {
+                    done(new Error('Error expected'));
+                })
+                .catch(function (err) {
+                    logger.info('EXPECTED ERROR: ' + err.stack);
                     assert.notEqual(err, null, 'err should not be null');
                     assert(err instanceof Error, 'expected Error should equal Error, was: ' + (typeof err));
                     done();

--- a/test/test-reader.js
+++ b/test/test-reader.js
@@ -1,10 +1,10 @@
 'use strict';
 
 var assert = require('assert');
-var YAMLException = require('js-yaml/lib/js-yaml/exception.js');
+var YAMLException = require('js-yaml/lib/js-yaml/exception');
 var fs = require('fs');
-var Reader = require('../index.js').Reader;
-var Constants = require('../index.js').constants;
+var Reader = require('../index').Reader;
+var Constants = require('../index').constants;
 var logger;
 var reader;
 

--- a/test/test-reader.js
+++ b/test/test-reader.js
@@ -13,8 +13,6 @@ var reader;
  */
 describe('Executing \'jy-transform\' project Reader test suite.', function () {
 
-    var invalidOrigin = 'INVALID_ORIGIN';
-
     /**
      * Init the test logger and Reader.
      */
@@ -136,25 +134,6 @@ describe('Executing \'jy-transform\' project Reader test suite.', function () {
             var options = {
                 src: './test/data/test-imports.js',
                 imports: exportsNotExists
-            };
-
-            reader.readJs(options)
-                .then(function (msg) {
-                    done(new Error('Error expected'));
-                })
-                .catch(function (err) {
-                    logger.info('EXPECTED ERROR: ' + err.stack);
-                    assert.notEqual(err, null, 'err should not be null');
-                    assert(err instanceof Error, 'expected Error should equal Error, was: ' + (typeof err));
-                    done();
-                });
-        });
-
-        it('should reject reading JS from stream with Error on invalid value for options.origin: ' + invalidOrigin, function (done) {
-
-            var options = {
-                src: fs.createReadStream('./test/data/test-imports.js'),
-                origin: invalidOrigin
             };
 
             reader.readJs(options)
@@ -527,25 +506,5 @@ describe('Executing \'jy-transform\' project Reader test suite.', function () {
                     done();
                 });
         });
-
-        it('should reject reading YAML from stream with Error on invalid value for options.origin: ' + invalidOrigin, function (done) {
-
-            var options = {
-                src: fs.createReadStream('./test/data/test-data.yaml'),
-                origin: invalidOrigin
-            };
-
-            reader.readYaml(options)
-                .then(function (msg) {
-                    done(new Error('Error expected'));
-                })
-                .catch(function (err) {
-                    logger.info('EXPECTED ERROR: ' + err.stack);
-                    assert.notEqual(err, null, 'err should not be null');
-                    assert(err instanceof Error, 'expected Error should equal Error, was: ' + (typeof err));
-                    done();
-                });
-        });
-
     });
 });

--- a/test/test-transformer.js
+++ b/test/test-transformer.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var Transformer = require('../index.js');
+var Transformer = require('../index');
 var transformer;
-var Constants = require('../lib/constants.js');
+var Constants = require('../lib/constants');
 var logger;
 var jsYaml = require('js-yaml');
 var assert = require('assert');

--- a/test/test-validator.js
+++ b/test/test-validator.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 var os = require('os');
 var stringify = require('json-stringify-safe');
 var stream = require('stream');
-var Validator = require('../lib/validator.js');
+var Validator = require('../lib/validator');
 var logger;
 var validator;
 

--- a/test/test-writer.js
+++ b/test/test-writer.js
@@ -7,7 +7,6 @@ var fs = require('fs');
 var os = require('os');
 var stream = require('stream');
 var Writer = require('../index').Writer;
-var Constants = require('../index').constants;
 var logger;
 var writer;
 
@@ -76,19 +75,6 @@ describe('Executing \'jy-transform\' project Writer test suite.', function () {
                 return done();
             }
         }
-    }
-
-    function assertDestBuffer(src, buffer, done) {
-        //var bufferToString = buffer.toString();
-        //logger.info('bufferToString::: ' + bufferToString);
-        var bufferResult = buffer.toJSON();
-        for (var property in bufferResult) {
-            if (bufferResult.hasOwnProperty(property)) {
-                assert(src.hasOwnProperty(property), 'src should have same property \'' + property +  '\' as buffer result object');
-                assert.equal(src[property], bufferResult[property], 'property \'' + property +  '\' should  have equal value in src (\'' + src[property] + '\') and buffer result object (\'' + bufferResult[property] + '\')');
-            }
-        }
-        done();
     }
 
     var json = {
@@ -401,27 +387,6 @@ describe('Executing \'jy-transform\' project Writer test suite.', function () {
                 .then(function (msg) {
                     assert.notEqual(msg, null, 'msg should not be null, was: ' + msg);
                     assertDestFile(file, done);
-                })
-                .catch(function (err) {
-                    logger.error(err.stack);
-                    done(err);
-                });
-        });
-
-        it('should write JSON to Buffer', function (done) {
-
-            var json = {
-                foo: 'bar'
-            };
-            var buffer = new Buffer(JSON.stringify(json, null, 4).length);
-            var options = {
-                dest: buffer
-            };
-
-            writer.writeJson(json, options)
-                .then(function (msg) {
-                    assert.notEqual(msg, null, 'msg should not be null, was: ' + msg);
-                    assertDestBuffer(json, buffer, done);
                 })
                 .catch(function (err) {
                     logger.error(err.stack);


### PR DESCRIPTION
- [[#33](https://github.com/deadratfink/jy-transform/issues/33)] Enhance `LogWrapper` with `TRACE` level (API)
- [[#32](https://github.com/deadratfink/jy-transform/issues/32)] Introduce input and output on CLI as ARGS instead of OPTIONS (non-backwards compatible change for CLI usage, _no_ impact on API level!)
 - e.g. on CLI type in `$ jyt foo.js bar.yaml` instead of `$ jyt -s foo.js -d bar.yaml`
- [[#31](https://github.com/deadratfink/jy-transform/issues/31)] Bugfix: given `Object` source results in 'yaml' for origin (API)
- [Cleanup] Update dependencies